### PR TITLE
support pre-loaded cell of fmap header in aamod_fieldmap2VDM

### DIFF
--- a/aa_modules/aamod_fieldmap2VDM.m
+++ b/aa_modules/aamod_fieldmap2VDM.m
@@ -73,7 +73,8 @@ switch task
         if ~isfield(job.data,'precalcfieldmap')
             try % Fieldmap EchoTimes
                 FM_DICOMHEADERS=load(aas_getfiles_bystream(aap,domain,[subj,sess],'fieldmap_dicom_header'));
-                if iscell(FM_DICOMHEADERS.dcmhdr)  
+                if iscell(FM_DICOMHEADERS.dcmhdr)
+                    assert(numel(FM_DICOMHEADERS.dcmhdr{1,1})==1, 'unexpected input');
                     tes = [FM_DICOMHEADERS.dcmhdr{1,1}.EchoTime1*1000,FM_DICOMHEADERS.dcmhdr{1,1}.EchoTime2*1000]; % in ms
                 else
                     tes = sort(unique(cellfun(@(x) x.volumeTE,FM_DICOMHEADERS.dcmhdr)),'ascend')*1000; % in ms

--- a/aa_modules/aamod_fieldmap2VDM.m
+++ b/aa_modules/aamod_fieldmap2VDM.m
@@ -73,7 +73,11 @@ switch task
         if ~isfield(job.data,'precalcfieldmap')
             try % Fieldmap EchoTimes
                 FM_DICOMHEADERS=load(aas_getfiles_bystream(aap,domain,[subj,sess],'fieldmap_dicom_header'));
-                tes = sort(unique(cellfun(@(x) x.volumeTE,FM_DICOMHEADERS.dcmhdr)),'ascend')*1000; % in ms
+                if iscell(FM_DICOMHEADERS.dcmhdr)  
+                    tes = [FM_DICOMHEADERS.dcmhdr{1,1}.EchoTime1*1000,FM_DICOMHEADERS.dcmhdr{1,1}.EchoTime2*1000]; % in ms
+                else
+                    tes = sort(unique(cellfun(@(x) x.volumeTE,FM_DICOMHEADERS.dcmhdr)),'ascend')*1000; % in ms
+                end
                 if numel(tes) ~= 2, tes = sort(unique(cellfun(@(x) x.EchoTime,FM_DICOMHEADERS.dcmhdr)),'ascend'); end % try original (backward compatibility)
                 if numel(tes) ~= 2, aas_log(aap,true,'Inappropriate fieldmap header!'); end
                 job.defaults.defaultsval.et = tes;


### PR DESCRIPTION
As with previous fieldmap problems fromBIDS, this is caused by the fieldmap dicomheader parameters already being loaded & being in a structure format not expected by aa. 

Specifically
Lines 74-75 reads the header and tries to read TE,  but the expected format (i.e. FM_DICOMHEADERS.dcmhdr.volumeTE) does not exist:

```
FM_DICOMHEADERS=load(aas_getfiles_bystream(aap,domain,subj,sess],'fieldmap_dicom_header'));
tes = sort(unique(cellfun(@(x) x.volumeTE,FM_DICOMHEADERS.dcmhdr)),'ascend')*1000; % in ms
	
Reference to non-existent field 'volumeTE'.
Error in `aamod_fieldmap2VDM>@(x)x.volumeTE
```
	
The change here first checks if FM_DICOMHEADERS.dcmhdr is a cell &, if so, skips looking for the volumeTE field.